### PR TITLE
GitHub Contribution のパース方法を修正

### DIFF
--- a/src/infrastructure/client/github/client.go
+++ b/src/infrastructure/client/github/client.go
@@ -3,6 +3,7 @@ package github
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -40,15 +41,24 @@ func (c *githubClient) Get(baseDate time.Time) (*entity.Contribution, error) {
 		BaseDate: baseDate,
 	}
 
+	r := regexp.MustCompile(`(\d+) contributions on`)
+
 	yesterday := baseDate.AddDate(0, 0, -1)
 	doc.Find(fmt.Sprintf("rect[data-date=\"%s\"]", baseDate.Format("2006-01-02"))).Each(func(i int, s *goquery.Selection) {
-		if v, err := strconv.Atoi(s.AttrOr("data-count", "0")); err == nil {
-			e.BaseDateCount = v
+		if r.MatchString(s.Text()) {
+			t := r.FindStringSubmatch(s.Text())[1]
+			fmt.Print("matched!!", t)
+			if v, err := strconv.Atoi(t); err == nil {
+				e.BaseDateCount = v
+			}
 		}
 	})
 	doc.Find(fmt.Sprintf("rect[data-date=\"%s\"]", yesterday.Format("2006-01-02"))).Each(func(i int, s *goquery.Selection) {
-		if v, err := strconv.Atoi(s.AttrOr("data-count", "0")); err == nil {
-			e.YesterdayCount = v
+		if r.MatchString(s.Text()) {
+			t := r.FindStringSubmatch(s.Text())[1]
+			if v, err := strconv.Atoi(t); err == nil {
+				e.YesterdayCount = v
+			}
 		}
 	})
 

--- a/src/infrastructure/client/github/client_test.go
+++ b/src/infrastructure/client/github/client_test.go
@@ -15,18 +15,18 @@ func TestGitHubGet(t *testing.T) {
 
 	reqUrl := fmt.Sprintf("https://github.com/users/%s/contributions", username)
 	httpmock.RegisterResponder("GET", reqUrl,
-		httpmock.NewStringResponder(200, "<rect data-date=\"2006-01-02\" data-count=\"1\" /><rect data-date=\"2006-01-01\" data-count=\"2\" />"))
+		httpmock.NewStringResponder(200, "<rect data-date=\"2006-01-02\">9 contributions on January 2, 2006</rect><rect data-date=\"2006-01-01\">12 contributions on January 1, 2006</rect>"))
 
 	r, err := c.Get(time.Date(2006, 1, 2, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	if r.YesterdayCount != 2 {
-		t.Errorf("Failed: Name is not matched, actual: [%d], expected: [%d]", r.YesterdayCount, 2)
+	if r.YesterdayCount != 12 {
+		t.Errorf("Failed: Count is not matched, actual: [%d], expected: [%d]", r.YesterdayCount, 12)
 	}
-	if r.BaseDateCount != 1 {
-		t.Errorf("Failed: Name is not matched, actual: [%d], expected: [%d]", r.BaseDateCount, 1)
+	if r.BaseDateCount != 9 {
+		t.Errorf("Failed: Count is not matched, actual: [%d], expected: [%d]", r.BaseDateCount, 9)
 	}
 	info := httpmock.GetCallCountInfo()
 	if info[fmt.Sprintf("GET %s", reqUrl)] != 1 {


### PR DESCRIPTION
- `data-count` 属性が消えていたことによりコントリビュート数が取得できていなかった
- 取り急ぎ rect タグ内のテキストから取得するよう修正
- 今後は GraphQL から取得したい ([参考](https://topaz.dev/recipes/b70f1010f9f447ce7289#GitHub%E3%81%AEGraphQL%20API%E3%82%92%E8%A9%A6%E3%81%97%E3%81%A6%E3%81%BF%E3%82%8B))