### PR TITLE
GitLab からデータを取得する際の上限を設定

### DIFF
--- a/src/infrastructure/client/gitlab/client.go
+++ b/src/infrastructure/client/gitlab/client.go
@@ -48,7 +48,9 @@ func (c *gitlabClient) response(baseDate time.Time) (int, error) {
 	// 前日～翌日を指定することで当日分を取得できる
 	before := baseDate.AddDate(0, 0, 1).Format("2006-01-02")
 	after := baseDate.AddDate(0, 0, -1).Format("2006-01-02")
-	res, err := http.Get(fmt.Sprintf("https://gitlab.com/api/v4/users/%s/events?private_token=%s&before=%s&after=%s", c.userID, c.token, before, after))
+	// 上限はひとまず100とする
+	perPage := 100
+	res, err := http.Get(fmt.Sprintf("https://gitlab.com/api/v4/users/%s/events?private_token=%s&before=%s&after=%s&per_page=%d", c.userID, c.token, before, after, perPage))
 	if err != nil {
 		return 0, err
 	}

--- a/src/infrastructure/client/gitlab/client_test.go
+++ b/src/infrastructure/client/gitlab/client_test.go
@@ -14,11 +14,11 @@ func TestGitHubGet(t *testing.T) {
 	c := gitlabClient{userID, token}
 	httpmock.Activate()
 
-	reqUrlForToday := fmt.Sprintf("https://gitlab.com/api/v4/users/%s/events?private_token=%s&before=2006-01-02&after=2005-12-31", userID, token)
+	reqUrlForToday := fmt.Sprintf("https://gitlab.com/api/v4/users/%s/events?private_token=%s&before=2006-01-02&after=2005-12-31&per_page=100", userID, token)
 	httpmock.RegisterResponder("GET", reqUrlForToday,
 		httpmock.NewStringResponder(200, "[ { \"id\": 1 }, { \"id\": 2 }, { \"id\": 3 } ]"))
 
-	reqUrlForYesterday := fmt.Sprintf("https://gitlab.com/api/v4/users/%s/events?private_token=%s&before=2006-01-03&after=2006-01-01", userID, token)
+	reqUrlForYesterday := fmt.Sprintf("https://gitlab.com/api/v4/users/%s/events?private_token=%s&before=2006-01-03&after=2006-01-01&per_page=100", userID, token)
 	httpmock.RegisterResponder("GET", reqUrlForYesterday,
 		httpmock.NewStringResponder(200, "[ { \"id\": 1 } ]"))
 


### PR DESCRIPTION
- 取得上限がデフォルト20件のため、100件とするように変更