### PR TITLE
GitHub App 認証に対応する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
-GITHUB_TOKEN="xxx"
+# GitHub App authentication is the default. Keep GITHUB_TOKEN empty unless using the legacy PAT fallback.
+GITHUB_TOKEN=""
+GITHUB_APP_ID="12345"
+GITHUB_APP_INSTALLATION_ID="67890"
+GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
 GITHUB_USER_NAME="user"
 GITLAB_USER_ID="12345678"
 GITLAB_TOKEN="xxx"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ $ cp .env.example .env # please edit values
 $ DEBUG=1 go run src/cmd/main.go
 ```
 
+GitHub App の private key は `\n` を含む1行の値として `GITHUB_APP_PRIVATE_KEY` に設定してください。
+
 ## Run with AWS SAM (scheduled Lambda)
 
 ```console
@@ -30,13 +32,23 @@ $ sam deploy --guided
 
 `template.yaml` では GitHub Actions と同じく毎日 `15:00 UTC` に実行するよう設定しています。
 
-`template.yaml` は Secrets Manager を前提にしています。少なくとも以下のキーを持つ Secret を作成してください。
+`template.yaml` は Secrets Manager を前提にしています。GitHub App 認証を使う場合は、以下のキーを持つ Secret を作成してください。
 
 ```json
 {
-  "GITHUB_TOKEN": "xxx",
+  "GITHUB_APP_ID": "12345",
+  "GITHUB_APP_INSTALLATION_ID": "67890",
+  "GITHUB_APP_PRIVATE_KEY": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
   "GITLAB_TOKEN": "xxx",
   "SLACK_WEBHOOK_URL": "xxx"
+}
+```
+
+PAT (`GITHUB_TOKEN`) は互換用の fallback として利用できます。ローカルなどで PAT を使う場合は、GitHub App の環境変数を未設定にしてください。
+
+```json
+{
+  "GITHUB_TOKEN": "xxx"
 }
 ```
 

--- a/src/app/config.go
+++ b/src/app/config.go
@@ -3,28 +3,35 @@ package app
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"gotoeveryone/notify-contributions/src/domain/entity"
 )
 
 type Config struct {
-	GitHubToken  string
-	GitHubUser   string
-	GitLabUserID string
-	GitLabToken  string
-	NotifyType   string
-	SlackWebhook string
-	TwitterAuth  entity.TwitterAuth
+	GitHubToken             string
+	GitHubUser              string
+	GitHubAppID             string
+	GitHubAppInstallationID string
+	GitHubAppPrivateKey     string
+	GitLabUserID            string
+	GitLabToken             string
+	NotifyType              string
+	SlackWebhook            string
+	TwitterAuth             entity.TwitterAuth
 }
 
 func LoadConfig() (*Config, error) {
 	cfg := &Config{
-		GitHubToken:  os.Getenv("GITHUB_TOKEN"),
-		GitHubUser:   os.Getenv("GITHUB_USER_NAME"),
-		GitLabUserID: os.Getenv("GITLAB_USER_ID"),
-		GitLabToken:  os.Getenv("GITLAB_TOKEN"),
-		NotifyType:   os.Getenv("NOTIFY_TYPE"),
-		SlackWebhook: os.Getenv("SLACK_WEBHOOK_URL"),
+		GitHubToken:             os.Getenv("GITHUB_TOKEN"),
+		GitHubUser:              os.Getenv("GITHUB_USER_NAME"),
+		GitHubAppID:             os.Getenv("GITHUB_APP_ID"),
+		GitHubAppInstallationID: os.Getenv("GITHUB_APP_INSTALLATION_ID"),
+		GitHubAppPrivateKey:     normalizePrivateKey(os.Getenv("GITHUB_APP_PRIVATE_KEY")),
+		GitLabUserID:            os.Getenv("GITLAB_USER_ID"),
+		GitLabToken:             os.Getenv("GITLAB_TOKEN"),
+		NotifyType:              os.Getenv("NOTIFY_TYPE"),
+		SlackWebhook:            os.Getenv("SLACK_WEBHOOK_URL"),
 		TwitterAuth: entity.TwitterAuth{
 			ConsumerKey:       os.Getenv("TWITTER_COMSUMER_KEY"),
 			ConsumerSecret:    os.Getenv("TWITTER_COMSUMER_SECRET"),
@@ -33,7 +40,7 @@ func LoadConfig() (*Config, error) {
 		},
 	}
 
-	if err := require("GITHUB_TOKEN", cfg.GitHubToken); err != nil {
+	if err := cfg.requireGitHubAuth(); err != nil {
 		return nil, err
 	}
 	if err := require("GITHUB_USER_NAME", cfg.GitHubUser); err != nil {
@@ -74,9 +81,39 @@ func LoadConfig() (*Config, error) {
 	return cfg, nil
 }
 
+func (c *Config) UseGitHubApp() bool {
+	return c.hasGitHubAppConfig() || c.GitHubToken == ""
+}
+
+func (c *Config) requireGitHubAuth() error {
+	if !c.UseGitHubApp() {
+		return require("GITHUB_TOKEN", c.GitHubToken)
+	}
+
+	if err := require("GITHUB_APP_ID", c.GitHubAppID); err != nil {
+		return err
+	}
+	if err := require("GITHUB_APP_INSTALLATION_ID", c.GitHubAppInstallationID); err != nil {
+		return err
+	}
+	if err := require("GITHUB_APP_PRIVATE_KEY", c.GitHubAppPrivateKey); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Config) hasGitHubAppConfig() bool {
+	return c.GitHubAppID != "" || c.GitHubAppInstallationID != "" || c.GitHubAppPrivateKey != ""
+}
+
 func require(key string, value string) error {
 	if value == "" {
 		return fmt.Errorf("%s is required", key)
 	}
 	return nil
+}
+
+func normalizePrivateKey(value string) string {
+	return strings.ReplaceAll(value, `\n`, "\n")
 }

--- a/src/app/config_test.go
+++ b/src/app/config_test.go
@@ -1,0 +1,46 @@
+package app
+
+import "testing"
+
+func TestConfigRequireGitHubAuthWithToken(t *testing.T) {
+	cfg := Config{GitHubToken: "token"}
+
+	if err := cfg.requireGitHubAuth(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConfigRequireGitHubAuthWithGitHubApp(t *testing.T) {
+	cfg := Config{
+		GitHubAppID:             "12345",
+		GitHubAppInstallationID: "67890",
+		GitHubAppPrivateKey:     "private_key",
+	}
+
+	if err := cfg.requireGitHubAuth(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConfigRequireGitHubAuthDefaultsToGitHubApp(t *testing.T) {
+	cfg := Config{}
+
+	err := cfg.requireGitHubAuth()
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+	if err.Error() != "GITHUB_APP_ID is required" {
+		t.Errorf("Error is not matched, actual: [%s], expected: [%s]", err.Error(), "GITHUB_APP_ID is required")
+	}
+}
+
+func TestConfigRequireGitHubAuthRequiresGitHubAppPrivateKey(t *testing.T) {
+	cfg := Config{
+		GitHubAppID:             "12345",
+		GitHubAppInstallationID: "67890",
+	}
+
+	if err := cfg.requireGitHubAuth(); err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+}

--- a/src/app/notify.go
+++ b/src/app/notify.go
@@ -15,7 +15,11 @@ func Notify(baseDate time.Time) error {
 		return err
 	}
 
-	ghc := registry.NewGitHubClient(cfg.GitHubUser, cfg.GitHubToken)
+	ghc, err := newGitHubClient(cfg)
+	if err != nil {
+		return err
+	}
+
 	glc := registry.NewGitlabClient(cfg.GitLabUserID, cfg.GitLabToken)
 
 	var nc client.Notification
@@ -33,4 +37,22 @@ func Notify(baseDate time.Time) error {
 		return err
 	}
 	return nil
+}
+
+func newGitHubClient(cfg *Config) (client.Contribution, error) {
+	if !cfg.UseGitHubApp() {
+		return registry.NewGitHubClient(cfg.GitHubUser, cfg.GitHubToken), nil
+	}
+
+	ghc, err := registry.NewGitHubAppClient(
+		cfg.GitHubUser,
+		cfg.GitHubAppID,
+		cfg.GitHubAppInstallationID,
+		cfg.GitHubAppPrivateKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return ghc, nil
 }

--- a/src/infrastructure/client/github/client.go
+++ b/src/infrastructure/client/github/client.go
@@ -13,14 +13,21 @@ import (
 )
 
 type githubClient struct {
-	username string
-	token    string
+	username      string
+	tokenProvider TokenProvider
 }
 
 func NewClient(username string, token string) client.Contribution {
 	return &githubClient{
-		username: username,
-		token:    token,
+		username:      username,
+		tokenProvider: NewStaticTokenProvider(token),
+	}
+}
+
+func NewClientWithTokenProvider(username string, tokenProvider TokenProvider) client.Contribution {
+	return &githubClient{
+		username:      username,
+		tokenProvider: tokenProvider,
 	}
 }
 
@@ -29,8 +36,13 @@ func (c *githubClient) Get(baseDate time.Time) (*entity.Contribution, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	token, err := c.tokenProvider.Token(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("github token acquisition failed: %w", err)
+	}
+
 	src := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: c.token},
+		&oauth2.Token{AccessToken: token},
 	)
 	httpClient := oauth2.NewClient(ctx, src)
 	ghClient := githubv4.NewClient(httpClient)

--- a/src/infrastructure/client/github/client_test.go
+++ b/src/infrastructure/client/github/client_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -9,11 +10,20 @@ import (
 
 func TestGitHubGet(t *testing.T) {
 	username := "test"
-	c := githubClient{username: username}
+	c := githubClient{
+		username:      username,
+		tokenProvider: NewStaticTokenProvider("github_token"),
+	}
 	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
 
 	httpmock.RegisterResponder("POST", "https://api.github.com/graphql",
-		httpmock.NewStringResponder(200, `
+		func(req *http.Request) (*http.Response, error) {
+			if req.Header.Get("Authorization") != "Bearer github_token" {
+				t.Errorf("Authorization header is not matched: %s", req.Header.Get("Authorization"))
+			}
+
+			return httpmock.NewStringResponse(200, `
     {
       "data": {
         "user": {
@@ -41,7 +51,8 @@ func TestGitHubGet(t *testing.T) {
           }
         }
       }
-    }`))
+    }`), nil
+		})
 
 	r, err := c.Get(time.Date(2006, 1, 2, 0, 0, 0, 0, time.UTC))
 	if err != nil {

--- a/src/infrastructure/client/github/token_provider.go
+++ b/src/infrastructure/client/github/token_provider.go
@@ -1,0 +1,195 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const githubAPIBaseURL = "https://api.github.com"
+
+// TokenProvider provides a GitHub API access token.
+type TokenProvider interface {
+	Token(ctx context.Context) (string, error)
+}
+
+type staticTokenProvider struct {
+	token string
+}
+
+func NewStaticTokenProvider(token string) TokenProvider {
+	return &staticTokenProvider{token: token}
+}
+
+func (p *staticTokenProvider) Token(_ context.Context) (string, error) {
+	return p.token, nil
+}
+
+type GitHubAppTokenProvider struct {
+	appID          int64
+	installationID string
+	privateKey     *rsa.PrivateKey
+	httpClient     *http.Client
+
+	mu        sync.Mutex
+	token     string
+	expiresAt time.Time
+}
+
+func NewGitHubAppTokenProvider(appID string, installationID string, privateKeyPEM string) (*GitHubAppTokenProvider, error) {
+	parsedAppID, err := strconv.ParseInt(appID, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid github app id: %w", err)
+	}
+
+	privateKey, err := parsePrivateKey(privateKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GitHubAppTokenProvider{
+		appID:          parsedAppID,
+		installationID: installationID,
+		privateKey:     privateKey,
+		httpClient:     http.DefaultClient,
+	}, nil
+}
+
+func (p *GitHubAppTokenProvider) Token(ctx context.Context) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.token != "" && time.Now().Before(p.expiresAt.Add(-1*time.Minute)) {
+		return p.token, nil
+	}
+
+	jwt, err := p.createJWT(time.Now())
+	if err != nil {
+		return "", err
+	}
+
+	token, expiresAt, err := p.createInstallationToken(ctx, jwt)
+	if err != nil {
+		return "", err
+	}
+
+	p.token = token
+	p.expiresAt = expiresAt
+
+	return token, nil
+}
+
+func (p *GitHubAppTokenProvider) createJWT(now time.Time) (string, error) {
+	header := map[string]string{
+		"alg": "RS256",
+		"typ": "JWT",
+	}
+	claims := map[string]int64{
+		"iat": now.Add(-1 * time.Minute).Unix(),
+		"exp": now.Add(10 * time.Minute).Unix(),
+		"iss": p.appID,
+	}
+
+	encodedHeader, err := encodeSegment(header)
+	if err != nil {
+		return "", err
+	}
+	encodedClaims, err := encodeSegment(claims)
+	if err != nil {
+		return "", err
+	}
+
+	unsignedToken := encodedHeader + "." + encodedClaims
+	hashed := sha256.Sum256([]byte(unsignedToken))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, p.privateKey, crypto.SHA256, hashed[:])
+	if err != nil {
+		return "", fmt.Errorf("github app jwt signing failed: %w", err)
+	}
+
+	return unsignedToken + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func (p *GitHubAppTokenProvider) createInstallationToken(ctx context.Context, jwt string) (string, time.Time, error) {
+	endpoint := fmt.Sprintf("%s/app/installations/%s/access_tokens", githubAPIBaseURL, p.installationID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	res, err := p.httpClient.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("github app installation token request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return "", time.Time{}, fmt.Errorf("github app installation token request failed: status=%d body=%s", res.StatusCode, string(body))
+	}
+
+	var response struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", time.Time{}, fmt.Errorf("github app installation token response decode failed: %w", err)
+	}
+	if response.Token == "" {
+		return "", time.Time{}, errors.New("github app installation token response did not include token")
+	}
+
+	return response.Token, response.ExpiresAt, nil
+}
+
+func encodeSegment(value interface{}) (string, error) {
+	b, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func parsePrivateKey(privateKeyPEM string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(privateKeyPEM))
+	if block == nil {
+		return nil, errors.New("github app private key must be PEM encoded")
+	}
+
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+
+	parsedKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("github app private key parse failed: %w", err)
+	}
+
+	key, ok := parsedKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("github app private key must be RSA private key")
+	}
+
+	return key, nil
+}

--- a/src/infrastructure/client/github/token_provider_test.go
+++ b/src/infrastructure/client/github/token_provider_test.go
@@ -1,0 +1,99 @@
+package github
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/jarcoal/httpmock"
+)
+
+func TestGitHubAppTokenProviderToken(t *testing.T) {
+	privateKey := generatePrivateKeyPEM(t)
+	provider, err := NewGitHubAppTokenProvider("12345", "67890", privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	requestCount := 0
+	httpmock.RegisterResponder("POST", "https://api.github.com/app/installations/67890/access_tokens",
+		func(req *http.Request) (*http.Response, error) {
+			requestCount++
+			if req.Header.Get("Authorization") == "" {
+				t.Error("Authorization header is empty")
+			}
+
+			return httpmock.NewStringResponse(201, `{
+				"token": "installation_token",
+				"expires_at": "2099-01-01T00:00:00Z"
+			}`), nil
+		})
+
+	token, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "installation_token" {
+		t.Errorf("Token is not matched, actual: [%s], expected: [%s]", token, "installation_token")
+	}
+
+	token, err = provider.Token(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "installation_token" {
+		t.Errorf("Token is not matched, actual: [%s], expected: [%s]", token, "installation_token")
+	}
+	if requestCount != 1 {
+		t.Errorf("Request count is not matched, actual: [%d], expected: [%d]", requestCount, 1)
+	}
+}
+
+func TestGitHubAppTokenProviderTokenExpiredCache(t *testing.T) {
+	privateKey := generatePrivateKeyPEM(t)
+	provider, err := NewGitHubAppTokenProvider("12345", "67890", privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider.token = "cached_token"
+	provider.expiresAt = time.Now().Add(30 * time.Second)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("POST", "https://api.github.com/app/installations/67890/access_tokens",
+		httpmock.NewStringResponder(201, `{
+			"token": "refreshed_token",
+			"expires_at": "2099-01-01T00:00:00Z"
+		}`))
+
+	token, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "refreshed_token" {
+		t.Errorf("Token is not matched, actual: [%s], expected: [%s]", token, "refreshed_token")
+	}
+}
+
+func generatePrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	}))
+}

--- a/src/registry/client.go
+++ b/src/registry/client.go
@@ -14,6 +14,16 @@ func NewGitHubClient(username string, token string) client.Contribution {
 	return github.NewClient(username, token)
 }
 
+// NewGitHubAppClient create client for about contribution using GitHub App authentication.
+func NewGitHubAppClient(username string, appID string, installationID string, privateKey string) (client.Contribution, error) {
+	tokenProvider, err := github.NewGitHubAppTokenProvider(appID, installationID, privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return github.NewClientWithTokenProvider(username, tokenProvider), nil
+}
+
 // NewGitlabClient create client for about contribution use Gitlab
 func NewGitlabClient(userID string, token string) client.Contribution {
 	return gitlab.NewClient(userID, token)

--- a/template.yaml
+++ b/template.yaml
@@ -5,7 +5,7 @@ Description: notify-contributions scheduled Lambda
 Parameters:
   AppSecretArn:
     Type: String
-    Description: Secrets Manager ARN that stores GITHUB_TOKEN, GITLAB_TOKEN, SLACK_WEBHOOK_URL
+    Description: Secrets Manager ARN that stores GitHub App values, GITLAB_TOKEN, SLACK_WEBHOOK_URL
   GithubUserName:
     Type: String
   GitlabUserId:
@@ -26,7 +26,9 @@ Resources:
       Timeout: 30
       Environment:
         Variables:
-          GITHUB_TOKEN: !Sub "{{resolve:secretsmanager:${AppSecretArn}:SecretString:GITHUB_TOKEN}}"
+          GITHUB_APP_ID: !Sub "{{resolve:secretsmanager:${AppSecretArn}:SecretString:GITHUB_APP_ID}}"
+          GITHUB_APP_INSTALLATION_ID: !Sub "{{resolve:secretsmanager:${AppSecretArn}:SecretString:GITHUB_APP_INSTALLATION_ID}}"
+          GITHUB_APP_PRIVATE_KEY: !Sub "{{resolve:secretsmanager:${AppSecretArn}:SecretString:GITHUB_APP_PRIVATE_KEY}}"
           GITHUB_USER_NAME: !Ref GithubUserName
           GITLAB_USER_ID: !Ref GitlabUserId
           GITLAB_TOKEN: !Sub "{{resolve:secretsmanager:${AppSecretArn}:SecretString:GITLAB_TOKEN}}"


### PR DESCRIPTION
## 概要

GitHub API の認証方式として GitHub App 認証を利用できるようにしました。

## 変更内容

- GitHub API 用トークン取得処理を `TokenProvider` として分離
- GitHub App の JWT を生成し、installation access token を発行する実装を追加
- `GITHUB_TOKEN` による PAT 認証は fallback として維持
- `GITHUB_TOKEN` が空の場合は GitHub App 認証を既定として扱うよう変更
- Lambda / ローカルで共通利用できるよう `GITHUB_APP_ID` / `GITHUB_APP_INSTALLATION_ID` / `GITHUB_APP_PRIVATE_KEY` を追加
- README、`.env.example`、`template.yaml` を更新
- 設定検証と GitHub App token provider のテストを追加

## 背景

PAT は個人アカウントに紐づき、有効期限管理や再発行が運用負荷になりやすいため、Lambda でもローカルでも同じコードで GitHub App 認証を利用できるようにしました。

## 確認

```console
go fmt ./...
go vet ./...
go test ./...
```

Closes #82