### PR TITLE
CI / Deploy に concurrency を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## 概要

- CI workflow に concurrency を追加
- Deploy workflow に concurrency を追加

## 目的

同一 workflow / 同一 ref の古い実行をキャンセルし、後続の実行だけを残すようにします。
これにより、連続 push 時の不要な CI / deploy 実行を抑制します。

## 影響範囲

- `.github/workflows/ci.yml`
- `.github/workflows/deploy.yml`

アプリケーションコードへの変更はありません。

## 確認

- `git diff --check`
